### PR TITLE
install intake from github

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,6 @@ ipython = ">=8.22.2,<8.23"
 cf_xarray = ">=0.9.0,<0.10"
 nodejs = ">=20.12.2,<20.13"
 pydap = ">=3.4.0,<3.5"
-intake-xarray = ">=0.7.0,<0.8"
 rasterio = ">=1.3.10,<1.4"
 asciitree = ">=0.3.3,<0.4"
 pooch = ">=1.8.1,<1.9"
@@ -35,4 +34,5 @@ xpublish_edr = {path = "./xpublish-edr", editable = true}
 xpublish_opendap = {path = "./xpublish-opendap", editable = true}
 xpublish_intake_provider = {path = "./xpublish-intake-provider", editable = true}
 xpublish_intake = {path = "./xpublish-intake", editable = true}
+intake = { git = "https://github.com/intake/intake.git", rev = "2abbfad05bd9e9b372f1937895834ab226785806" }
 # xpublish_catalog = {path = "./xpublish-catalog", editable = true}


### PR DESCRIPTION
it has not been released lately and needs critical changes that are only on github. Also Martin is about to merge PR 810 https://github.com/intake/intake/pull/810 which has a change we need for xpublish-intake so will need to bump up to include that.